### PR TITLE
Add CategoryService and ProductService classes

### DIFF
--- a/eCommerceApp.Application/DependencyInjection/ServiceContainer.cs
+++ b/eCommerceApp.Application/DependencyInjection/ServiceContainer.cs
@@ -1,0 +1,30 @@
+﻿using eCommerceApp.Application.Mapping;
+using eCommerceApp.Application.Services.Implementations;
+using eCommerceApp.Application.Services.Interfaces;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace eCommerceApp.Application.DependencyInjection;
+
+/// <summary>
+/// Provides extension methods to register application services in the dependency injection container.
+/// </summary>
+public static class ServiceContainer
+{
+    /// <summary>
+    /// Adds application services to the specified <see cref="IServiceCollection"/>.
+    /// </summary>
+    /// <param name="services">The <see cref="IServiceCollection"/> to add services to.</param>
+    /// <returns>The <see cref="IServiceCollection"/> with the added services.</returns>
+    public static IServiceCollection AddApplicationService
+        (this IServiceCollection services)
+    {
+        // Configure the AutoMapper
+        services.AddAutoMapper(typeof(MappingConfiguration));
+
+        // Register Services
+        services.AddScoped<IProductService, ProductService>();
+        services.AddScoped<ICategoryService, CategoryService>();
+
+        return services;
+    }
+}

--- a/eCommerceApp.Application/Mapping/MappingConfiguration.cs
+++ b/eCommerceApp.Application/Mapping/MappingConfiguration.cs
@@ -1,0 +1,25 @@
+﻿using AutoMapper;
+using eCommerceApp.Application.DTOs.Category;
+using eCommerceApp.Application.DTOs.Product;
+using eCommerceApp.Domain.Entities;
+
+namespace eCommerceApp.Application.Mapping;
+
+/// <summary>
+/// Configuration class for setting up AutoMapper mappings.
+/// </summary>
+public class MappingConfiguration : Profile
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MappingConfiguration"/> class.
+    /// Sets up the mappings between DTOs and domain entities.
+    /// </summary>
+    public MappingConfiguration()
+    {
+        CreateMap<CreateCategoryDto, Category>();
+        CreateMap<CreateProductDto, Product>();
+
+        CreateMap<Category, GetCategoryDto>();
+        CreateMap<Product, GetProductDto>();
+    }
+}

--- a/eCommerceApp.Application/Services/Implementations/CategoryService.cs
+++ b/eCommerceApp.Application/Services/Implementations/CategoryService.cs
@@ -1,0 +1,44 @@
+﻿using eCommerceApp.Application.DTOs;
+using eCommerceApp.Application.DTOs.Category;
+using eCommerceApp.Application.Services.Interfaces;
+using eCommerceApp.Domain.Entities;
+using eCommerceApp.Domain.Interfaces;
+
+namespace eCommerceApp.Application.Services.Implementations;
+
+public class CategoryService : ICategoryService
+{
+    private readonly IGeneric<Category> _categoryInterface;
+
+    public CategoryService(IGeneric<Category> categoryInterface)
+    {
+        _categoryInterface = categoryInterface;
+    }
+
+    #region Methods
+    public Task<ServiceResponse> AddAsync(CreateCategoryDto category)
+    {
+        throw new NotImplementedException();
+    }
+
+    public Task<ServiceResponse> DeleteAsync(Guid id)
+    {
+        throw new NotImplementedException();
+    }
+
+    public Task<IEnumerable<GetCategoryDto>> GetAllAsync()
+    {
+        throw new NotImplementedException();
+    }
+
+    public Task<GetCategoryDto> GetByIdAsync(Guid id)
+    {
+        throw new NotImplementedException();
+    }
+
+    public Task<ServiceResponse> UpdateAsync(UpdateCategoryDto category)
+    {
+        throw new NotImplementedException();
+    }
+    #endregion
+}

--- a/eCommerceApp.Application/Services/Implementations/ProductService.cs
+++ b/eCommerceApp.Application/Services/Implementations/ProductService.cs
@@ -1,0 +1,44 @@
+﻿using eCommerceApp.Application.DTOs;
+using eCommerceApp.Application.DTOs.Product;
+using eCommerceApp.Application.Services.Interfaces;
+using eCommerceApp.Domain.Entities;
+using eCommerceApp.Domain.Interfaces;
+
+namespace eCommerceApp.Application.Services.Implementations;
+
+public class ProductService : IProductService
+{
+    private readonly IGeneric<Product> _productInterface;
+
+    public ProductService(IGeneric<Product> productInterface)
+    {
+        _productInterface = productInterface;
+    }
+
+    #region Mehtods
+    public Task<ServiceResponse> AddAsync(CreateProductDto product)
+    {
+        throw new NotImplementedException();
+    }
+
+    public Task<ServiceResponse> DeleteAsync(Guid id)
+    {
+        throw new NotImplementedException();
+    }
+
+    public Task<IEnumerable<GetProductDto>> GetAllAsync()
+    {
+        throw new NotImplementedException();
+    }
+
+    public Task<GetProductDto> GetByIdAsync(Guid id)
+    {
+        throw new NotImplementedException();
+    }
+
+    public Task<ServiceResponse> UpdateAsync(UpdateProductDto product)
+    {
+        throw new NotImplementedException();
+    }
+    #endregion
+}

--- a/eCommerceApp.Application/eCommerceApp.Application.csproj
+++ b/eCommerceApp.Application/eCommerceApp.Application.csproj
@@ -7,6 +7,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="AutoMapper" Version="14.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\eCommerceApp.Domain\eCommerceApp.Domain.csproj" />
   </ItemGroup>
 


### PR DESCRIPTION
Introduced `CategoryService` and `ProductService` to handle operations for `Category` and `Product` entities, respectively. Both classes implement their interfaces and utilize a generic interface for CRUD operations. All methods currently throw `NotImplementedException`. Fixed using directives for necessary DTOs. Note: `ProductService` has a typo in the region name ("Mehtods").