### PR TITLE
Refactor Product retrieval and enhance specifications

### DIFF
--- a/PrimeCare.Api/Controllers/ProductController.cs
+++ b/PrimeCare.Api/Controllers/ProductController.cs
@@ -32,7 +32,10 @@ public class ProductController : ControllerBase
 
     [HttpGet("{id}")]
     public async Task<ActionResult<Product?>> GetProduct(int id)
-        => await _productRepo.GetByIdAsync(id);
+    {
+        var specification = new ProductsWithTypesAndBrandsSpecification(id);
+        return await _productRepo.GetEntityWithSpecification(specification);
+    }
 
     [HttpGet("brands")]
     public async Task<ActionResult<IReadOnlyList<ProductBrand>>> GetProductBrands()

--- a/PrimeCare.Core/Specifications/ProductsWithTypesAndBrandsSpecification.cs
+++ b/PrimeCare.Core/Specifications/ProductsWithTypesAndBrandsSpecification.cs
@@ -2,9 +2,26 @@
 
 namespace PrimeCare.Core.Specifications;
 
+/// <summary>
+/// Specification for products with their types and brands included.
+/// </summary>
 public class ProductsWithTypesAndBrandsSpecification : BaseSpecification<Product>
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ProductsWithTypesAndBrandsSpecification"/> class.
+    /// </summary>
     public ProductsWithTypesAndBrandsSpecification()
+    {
+        AddInclude(x => x.ProductType);
+        AddInclude(x => x.ProductBrand);
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ProductsWithTypesAndBrandsSpecification"/> class with a specific product ID.
+    /// </summary>
+    /// <param name="id">The product identifier.</param>
+    public ProductsWithTypesAndBrandsSpecification(int id)
+        : base(x => x.Id == id)
     {
         AddInclude(x => x.ProductType);
         AddInclude(x => x.ProductBrand);


### PR DESCRIPTION
Updated the `GetProduct` method in `ProductController` to use a specification for retrieving products with their types and brands. Added a new constructor in `ProductsWithTypesAndBrandsSpecification` to initialize with a specific product ID, improving flexibility. Included XML documentation for better clarity on class usage.