### PR TITLE
Add error handling route and API explorer settings

### DIFF
--- a/PrimeCare.Api/Controllers/ErrorController.cs
+++ b/PrimeCare.Api/Controllers/ErrorController.cs
@@ -2,7 +2,9 @@
 using PrimeCare.Application.Errors;
 
 namespace PrimeCare.Api.Controllers;
+
 [Route("error/{code}")]
+[ApiExplorerSettings(IgnoreApi = true)]
 public class ErrorController : BaseApiController
 {
     public IActionResult Error(int code)


### PR DESCRIPTION
Updated the `ErrorController` class to include a route attribute for error handling (`[Route("error/{code}")]`) and an API explorer settings attribute to ignore this controller in API documentation (`[ApiExplorerSettings(IgnoreApi = true)]`).