### PR TITLE
Update category handling to use UpdateCategoryDto

### DIFF
--- a/PrimeCare.Api/Controllers/CategoryController.cs
+++ b/PrimeCare.Api/Controllers/CategoryController.cs
@@ -43,7 +43,7 @@ public class CategoryController : BaseApiController
     }
 
     [HttpPut("update")]
-    public async Task<IActionResult> Update(CategoryDto category)
+    public async Task<IActionResult> Update(UpdateCategoryDto category)
     {
         if (!ModelState.IsValid) return BadRequest(ModelState);
 

--- a/PrimeCare.Application/Services/Implementations/CategoryService.cs
+++ b/PrimeCare.Application/Services/Implementations/CategoryService.cs
@@ -69,7 +69,7 @@ public class CategoryService : ICategoryService
     /// </summary>
     /// <param name="entity">The category data transfer object (DTO) to be updated.</param>
     /// <returns>A task that represents the asynchronous operation. The task result contains the service response indicating success or failure.</returns>
-    public async Task<ServiceResponse> UpdateAsync(CategoryDto entity)
+    public async Task<ServiceResponse> UpdateAsync(UpdateCategoryDto entity)
     {
         var category = await _categoryInterface.GetByIdAsync(entity.Id);
         if (category == null)

--- a/PrimeCare.Application/Services/Interfaces/ICategoryService.cs
+++ b/PrimeCare.Application/Services/Interfaces/ICategoryService.cs
@@ -9,6 +9,6 @@ public interface ICategoryService
     Task<CategoryDto> GetByIdAsync(int id);
     Task<IReadOnlyList<CategoryDto>> GetAllAsync();
     Task<ServiceResponse> AddAsync(CreateCategoryDto entity);
-    Task<ServiceResponse> UpdateAsync(CategoryDto entity);
+    Task<ServiceResponse> UpdateAsync(UpdateCategoryDto entity);
     Task<ServiceResponse> DeleteAsync(int id);
 }


### PR DESCRIPTION
Modified the `Update` method in `CategoryController` to accept `UpdateCategoryDto` instead of `CategoryDto`. Updated the `UpdateAsync` method in `CategoryService` to align with this change. Reflected the new parameter type in the `ICategoryService` interface to ensure consistency across implementations.